### PR TITLE
Dates before 1905 cannot be put into a UNIX timestamp

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,6 +95,9 @@ def get_album_release_epoch(album=None, song_data=None):
 
         if date.isnumeric():
             year = int(date)
+            # Dates before 1905 are not representable with a unix timestamp
+            if year < 1905:
+                return LONG_TIME_AGO
             epoch = datetime.datetime(year, 1, 1)
         else:
             split_char: str


### PR DESCRIPTION
This works around #3. I think it'd be better to get rid of the UNIX timestamp altogether though; it will be clearer. I think it's perfectly possible to sort on raw datetime's.

If you indeed get rid of the epoch, please note that Pythons `datetime` only goes to year 1 (`datetime.MINYEAR`), not to year 0, so you'll have to account for that :-)

Ruben